### PR TITLE
FASTA: Added support for QUEUED response from jobdispatcher

### DIFF
--- a/sequence/fasta/src/main/java/uk/co/flax/biosolr/pdbe/fasta/FastaJob.java
+++ b/sequence/fasta/src/main/java/uk/co/flax/biosolr/pdbe/fasta/FastaJob.java
@@ -111,7 +111,7 @@ public class FastaJob implements Runnable {
         Thread.sleep(200);
         status = fasta.getStatus(jobId);
         LOG.debug("status=" + status);
-      } while (status.equals(FastaStatus.RUNNING));
+      } while (status.equals(FastaStatus.RUNNING) || status.equals(FastaStatus.QUEUED));
 
       if (!status.equals(FastaStatus.DONE)) {
         LOG.error("Error with job: " + jobId + " (" + status + ")");

--- a/sequence/fasta/src/main/java/uk/co/flax/biosolr/pdbe/fasta/FastaStatus.java
+++ b/sequence/fasta/src/main/java/uk/co/flax/biosolr/pdbe/fasta/FastaStatus.java
@@ -4,5 +4,6 @@ public class FastaStatus {
 
   public static final String RUNNING = "RUNNING";
   public static final String DONE = "FINISHED";
+  public static final String QUEUED = "QUEUED";
 
 }


### PR DESCRIPTION
Hi,
We identified an issue in the PDBe sequence search due to recent changes in EBI webservice where there is an additional QUEUED 200 response. Below is the error stack trace. 
This PR is to fix this issue.

> "msg":"Unexpected FASTA job status: QUEUED",
> "trace":"java.lang.RuntimeException: Unexpected FASTA job status: QUEUED\n\tat uk.co.flax.biosolr.pdbe.fasta.FastaXJoinResultsFactory.getResults(FastaXJoinResultsFactory.java:145)\n\tat org.apache.solr.search.xjoin.XJoinSearchComponent.prepare(XJoinSearchComponent.java:115)\n\tat org.apache.solr.handler.component.SearchHandler.handleRequestBody(SearchHandler.java:269)\n\tat