### PR TITLE
fix: Phmmer enhance e-value handling to support both number and string types

### DIFF
--- a/sequence/phmmer/src/main/java/uk/co/flax/biosolr/pdbe/phmmer/Alignment.java
+++ b/sequence/phmmer/src/main/java/uk/co/flax/biosolr/pdbe/phmmer/Alignment.java
@@ -2,6 +2,7 @@ package uk.co.flax.biosolr.pdbe.phmmer;
 
 import javax.json.JsonArray;
 import javax.json.JsonObject;
+import javax.json.JsonValue;
 
 public class Alignment {
   
@@ -60,18 +61,37 @@ public class Alignment {
     species = hit.getString("species");
     description = hit.getString("desc");
     score = Double.parseDouble(hit.getString("score"));
-    eValue = Double.parseDouble(hit.getString("evalue"));
+
+    JsonValue eValueJSON = hit.get("evalue");
+
+    if (eValueJSON.getValueType() == JsonValue.ValueType.NUMBER) {
+      eValue = hit.getJsonNumber("evalue").doubleValue();
+    } else if (eValueJSON.getValueType() == JsonValue.ValueType.STRING) {
+      eValue = Double.parseDouble(hit.getString("evalue"));
+    }
 
     JsonArray domains = hit.getJsonArray("domains");
     for (int i = 0; i < domains.size(); ++i) {
       JsonObject domain = domains.getJsonObject(i);
       
       // skip insignificant matches (by ind. eValue)
-      eValueInd = Double.parseDouble(domain.getString("ievalue"));
+      JsonValue eValue = domain.get("ievalue");
+      if (eValue.getValueType() == JsonValue.ValueType.NUMBER) {
+        eValueInd = domain.getJsonNumber("ievalue").doubleValue();
+      } else if (eValue.getValueType() == JsonValue.ValueType.STRING) {
+        eValueInd = Double.parseDouble(domain.getString("ievalue"));
+      }
+
       if (eValueInd >= SIGNIFICANCE_THRESHOLD) continue;
-      
-      eValueCond = Double.parseDouble(domain.getString("cevalue"));
-      
+
+      JsonValue ceValue = domain.get("cevalue");
+
+      if (ceValue.getValueType() == JsonValue.ValueType.NUMBER) {
+        eValueCond = domain.getJsonNumber("cevalue").doubleValue();
+      } else if (ceValue.getValueType() == JsonValue.ValueType.STRING) {
+        eValueCond = Double.parseDouble(domain.getString("cevalue"));
+      }
+
       querySequence = domain.getString("alimodel");
       querySequenceStart = domain.getInt("alihmmfrom");
       querySequenceEnd = domain.getInt("alihmmto");


### PR DESCRIPTION
This pull request introduces changes to the `Alignment` class in the `sequence/phmmer` module to improve the handling of JSON values for e-values. The most important changes include adding the `JsonValue` import and modifying the constructor to handle both numeric and string representations of e-values.

This is a fix to handle the ClassCastException in handling some fields from the Phmmer response.

**Error stack trace**
```
o.a.s.s.HttpSolrCall null:java.lang.ClassCastException: org.glassfish.json.JsonNumberImpl$JsonBigDecimalNumber cannot be cast to javax.json.JsonString
        at org.glassfish.json.JsonObjectBuilderImpl$JsonObjectImpl.getJsonString(JsonObjectBuilderImpl.java:194)
        at org.glassfish.json.JsonObjectBuilderImpl$JsonObjectImpl.getString(JsonObjectBuilderImpl.java:199)
        at uk.co.flax.biosolr.pdbe.phmmer.Alignment.<init>(Alignment.java:66)
        at uk.co.flax.biosolr.pdbe.phmmer.PhmmerJob.runJob(PhmmerJob.java:29)
        at uk.co.flax.biosolr.pdbe.phmmer.PhmmerXJoinResultsFactory.getResults(PhmmerXJoinResultsFactory.java:89)
```

Changes to handle JSON values:

* [`sequence/phmmer/src/main/java/uk/co/flax/biosolr/pdbe/phmmer/Alignment.java`](diffhunk://#diff-4c317138af1a08f3627170c68b14962cdad030e5be209057c74a2c4434578439R5): Added import for `JsonValue`.
* [`sequence/phmmer/src/main/java/uk/co/flax/biosolr/pdbe/phmmer/Alignment.java`](diffhunk://#diff-4c317138af1a08f3627170c68b14962cdad030e5be209057c74a2c4434578439R64-R93): Modified the `public Alignment(JsonObject hit)` constructor to handle both numeric and string representations of `evalue`, `ievalue`, and `cevalue`.